### PR TITLE
take out cleanup step

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=6"
   },
   "scripts": {
-    "start": "rm -rf dist && tsc && node ."
+    "start": "tsc && node ."
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Take out compiled js files' target `dist/` folder removal step from `npm start` script, since it doesn't work on Windows.